### PR TITLE
Fix command injection in app-store CLI

### DIFF
--- a/packages/app-store-cli/src/utils/execSync.ts
+++ b/packages/app-store-cli/src/utils/execSync.ts
@@ -1,26 +1,39 @@
-import child_process from "child_process";
+import { execFile } from "child_process";
 
-const execSync = async (cmd: string) => {
-  const silent = process.env.DEBUG === "1" ? false : true;
-  if (!silent) {
-    console.log(`${process.cwd()}$: ${cmd}`);
-  }
-  const result: string = await new Promise((resolve, reject) => {
-    child_process.exec(cmd, (err, stdout, stderr) => {
+const execFileAsync = (
+  file: string,
+  args: string[]
+) =>
+  new Promise<{ stdout: string; stderr: string }>((resolve, reject) => {
+    execFile(file, args, (err, stdout, stderr) => {
       if (err) {
         reject(err);
-        console.log(err);
+        return;
       }
-      if (stderr && !silent) {
-        console.log(stderr);
-      }
-      resolve(stdout);
+      resolve({ stdout: stdout.toString(), stderr: stderr.toString() });
     });
   });
 
+const execSync = async (command: string, args: string[] = []) => {
+  const silent = process.env.DEBUG === "1" ? false : true;
   if (!silent) {
-    console.log(result.toString());
+    console.log(`${process.cwd()}$: ${command} ${args.join(" ")}`.trim());
   }
-  return cmd;
+  try {
+    const { stdout, stderr } = await execFileAsync(command, args);
+    if (!silent && stderr) {
+      console.log(stderr);
+    }
+    if (!silent && stdout) {
+      console.log(stdout);
+    }
+  } catch (err) {
+    if (!silent && err) {
+      console.log(err);
+    }
+    throw err;
+  }
+
+  return command;
 };
 export default execSync;


### PR DESCRIPTION
## Summary
- prevent command injection by replacing `exec` with `execFile`
- update `core.ts` to pass args array to safe exec wrapper

## Testing
- `yarn lint packages/app-store-cli` *(fails: Error when performing the request to https://repo.yarnpkg.com/3.4.1/...)*
- `yarn test packages/app-store-cli` *(fails: Error when performing the request to https://repo.yarnpkg.com/3.4.1/...)*

------
https://chatgpt.com/codex/tasks/task_b_683e9da19cd88328a2ea2309064dfdcf